### PR TITLE
Revert registry changes

### DIFF
--- a/ansible/kayobe-automation-run-tempest.yml
+++ b/ansible/kayobe-automation-run-tempest.yml
@@ -4,16 +4,16 @@
   gather_facts: false
   vars:
     results_path_local: "{{ lookup('env', 'PWD') }}"
-    rally_image: 'stackhpc/docker-rally'
+    rally_image: 'gwee/rally'
     rally_tag: latest
     rally_image_full: "{{ rally_image }}:{{ rally_tag }}"
     rally_no_sensitive_log: false
     # This ensures you get the latest image if the image is updated
     # and the tag isn't e.g when using the latest tag.
     rally_force_pull: true
-    rally_docker_registry: ghcr.io
-    rally_docker_registry_username:
-    rally_docker_registry_password:
+    rally_docker_registry: "{{ kolla_docker_registry }}"
+    rally_docker_registry_username: "{{ kolla_docker_registry_username }}"
+    rally_docker_registry_password: "{{ kolla_docker_registry_password }}"
     load_list_path_remote: "{{ results_path_remote.path }}/tempest-load-list"
     skip_list_path_remote: "{{ results_path_remote.path }}/tempest-skip-list"
     accounts_path_remote: "{{ results_path_remote.path }}/tempest-accounts"
@@ -47,7 +47,7 @@
 
       - name: Ensure rally image exists on runner
         docker_image:
-          name: "{{ rally_docker_registry }}/{{ rally_image_full }}"
+          name: "{{ rally_image_full }}"
           state: present
           force_source: "{{ rally_force_pull | bool }}"
           source: pull

--- a/ansible/kayobe-automation-run-tempest.yml
+++ b/ansible/kayobe-automation-run-tempest.yml
@@ -6,7 +6,7 @@
     results_path_local: "{{ lookup('env', 'PWD') }}"
     rally_image: 'stackhpc/docker-rally'
     rally_tag: latest
-    rally_image_full: "{{ rally_docker_registry }}/{{ rally_image }}:{{ rally_tag }}"
+    rally_image_full: "{{ rally_image }}:{{ rally_tag }}"
     rally_no_sensitive_log: false
     # This ensures you get the latest image if the image is updated
     # and the tag isn't e.g when using the latest tag.
@@ -47,7 +47,7 @@
 
       - name: Ensure rally image exists on runner
         docker_image:
-          name: "{{ rally_image_full }}"
+          name: "{{ rally_docker_registry }}/{{ rally_image_full }}"
           state: present
           force_source: "{{ rally_force_pull | bool }}"
           source: pull


### PR DESCRIPTION
the latest rally image containing latest master changes doesn't want to run on wallaby-staging. reverting to the old image which was previously known to work.

